### PR TITLE
movie_support

### DIFF
--- a/Jellyfin.Plugin.ThePornDB/Consts.cs
+++ b/Jellyfin.Plugin.ThePornDB/Consts.cs
@@ -4,7 +4,7 @@ namespace ThePornDB
     {
         public const string BaseURL = "https://metadataapi.net";
 
-        public const string SceneURL = BaseURL + "/scenes/{0}";
+        public const string VideoURL = BaseURL + "{0}";
 
         public const string PerfomerURL = BaseURL + "/performers/{0}";
 
@@ -14,7 +14,9 @@ namespace ThePornDB
 
         public const string APISceneSearchURL = APIBaseURL + "/scenes?parse={0}&hash={1}";
 
-        public const string APISceneURL = APIBaseURL + "/scenes/{0}";
+        public const string APIMovieSearchURL = APIBaseURL + "/movies?parse={0}&hash={1}";
+
+        public const string APIVideoURL = APIBaseURL + "{0}";
 
         public const string APIPerfomerSearchURL = APIBaseURL + "/performers?q={0}";
 

--- a/Jellyfin.Plugin.ThePornDB/ExternalIds/Movies.cs
+++ b/Jellyfin.Plugin.ThePornDB/ExternalIds/Movies.cs
@@ -21,7 +21,7 @@ namespace ThePornDB
 
         public string Key => Plugin.Instance.Name;
 
-        public string UrlFormatString => Consts.SceneURL;
+        public string UrlFormatString => Consts.VideoURL;
 
         public bool Supports(IHasProviderIds item) => item is Movie;
     }

--- a/Jellyfin.Plugin.ThePornDB/Providers/MetadataAPI.cs
+++ b/Jellyfin.Plugin.ThePornDB/Providers/MetadataAPI.cs
@@ -55,24 +55,44 @@ namespace ThePornDB.Providers
                 return result;
             }
 
+            // Seach Scenes
             var url = string.Format(Consts.APISceneSearchURL, searchTitle, oshash);
 
             var data = await GetDataFromAPI(url, cancellationToken).ConfigureAwait(false);
 
-            if (data == null || !data.ContainsKey("data") || data["data"].Type != JTokenType.Array)
+            if (data != null && data.ContainsKey("data") && data["data"].Type == JTokenType.Array)
             {
-                return result;
+
+                foreach (var searchResult in data["data"])
+                {
+                    result.Add(new RemoteSearchResult
+                    {
+                        ProviderIds = { { Plugin.Instance.Name, "/scenes/"+(string)searchResult["id"] } },
+                        Name = (string)searchResult["title"],
+                        ImageUrl = (string)searchResult["poster"],
+                        PremiereDate = (DateTime)searchResult["date"],
+                    });
+                }
             }
 
-            foreach (var searchResult in data["data"])
+            // Seach Movies
+            url = string.Format(Consts.APIMovieSearchURL, searchTitle, oshash);
+
+            data = await GetDataFromAPI(url, cancellationToken).ConfigureAwait(false);
+
+            if (data != null && data.ContainsKey("data") && data["data"].Type == JTokenType.Array)
             {
-                result.Add(new RemoteSearchResult
+
+                foreach (var searchResult in data["data"])
                 {
-                    ProviderIds = { { Plugin.Instance.Name, (string)searchResult["id"] } },
-                    Name = (string)searchResult["title"],
-                    ImageUrl = (string)searchResult["poster"],
-                    PremiereDate = (DateTime)searchResult["date"],
-                });
+                    result.Add(new RemoteSearchResult
+                    {
+                        ProviderIds = { { Plugin.Instance.Name, "/movies/"+(string)searchResult["id"] } },
+                        Name = (string)searchResult["title"],
+                        ImageUrl = (string)searchResult["poster"],
+                        PremiereDate = (DateTime)searchResult["date"],
+                    });
+                }
             }
 
             return result;
@@ -91,7 +111,7 @@ namespace ThePornDB.Providers
                 return result;
             }
 
-            var url = string.Format(Consts.APISceneURL, sceneID);
+            var url = string.Format(Consts.APIVideoURL, sceneID);
             var sceneData = await GetDataFromAPI(url, cancellationToken).ConfigureAwait(false);
             if (sceneData == null || !sceneData.ContainsKey("data") || sceneData["data"].Type != JTokenType.Object)
             {
@@ -211,7 +231,8 @@ namespace ThePornDB.Providers
                 return result;
             }
 
-            var url = string.Format(Consts.APISceneURL, sceneID);
+            var url = string.Format(Consts.APIVideoURL, sceneID);
+
             var sceneData = await GetDataFromAPI(url, cancellationToken).ConfigureAwait(false);
             if (sceneData == null || !sceneData.ContainsKey("data") || sceneData["data"].Type != JTokenType.Object)
             {


### PR DESCRIPTION
Attempt to look up movies as well as scenes with the jellyfin plugin.

This lookup will attempt to find both scenes and movies.   Generally even if scenes and movies are duplicated this shouldn't be a problem as in most cases the dates will differ, resulting in one best match.

This code is untested as I couldn't build locally on a mac.