### PR TITLE
feat: add tag filtering and mapping options

### DIFF
--- a/Jellyfin.Plugin.ThePornDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.ThePornDB/Configuration/PluginConfiguration.cs
@@ -19,6 +19,13 @@ namespace ThePornDB.Configuration
         Disabled = 2,
     }
 
+    public enum TagFilterMode
+    {
+        Disabled = 0,
+        Blacklist = 1,
+        Whitelist = 2,
+    }
+
     public enum CollectionType
     {
         Scene = 0,
@@ -77,6 +84,9 @@ namespace ThePornDB.Configuration
 
             this.OrderStyle = OrderStyle.Default;
             this.TagStyle = TagStyle.Genre;
+            this.TagFilterMode = TagFilterMode.Disabled;
+            this.TagFilterList = string.Empty;
+            this.TagMappings = string.Empty;
 
             this.AddCollectionOnSite = false;
 
@@ -121,6 +131,12 @@ namespace ThePornDB.Configuration
         public OrderStyle OrderStyle { get; set; }
 
         public TagStyle TagStyle { get; set; }
+
+        public TagFilterMode TagFilterMode { get; set; }
+
+        public string TagFilterList { get; set; }
+
+        public string TagMappings { get; set; }
 
         public bool AddCollectionOnSite { get; set; }
 

--- a/Jellyfin.Plugin.ThePornDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.ThePornDB/Configuration/configPage.html
@@ -33,6 +33,24 @@
                         </select>
                     </div>
                     <div class="selectContainer">
+                        <label class="selectLabel" for="TagFilterMode">Tag Filter Mode</label>
+                        <select is="emby-select" id="TagFilterMode" name="TagFilterMode" class="emby-select-withcolor emby-select">
+                            <option value="Disabled">Disabled</option>
+                            <option value="Blacklist">Blacklist</option>
+                            <option value="Whitelist">Whitelist</option>
+                        </select>
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="TagFilterList">Tag Filter List (comma-separated)</label>
+                        <textarea is="emby-textarea" id="TagFilterList" class="textarea-mono emby-textarea" rows="3" style="overflow-y: hidden; height: 60px; width: 100%;" placeholder="Tag1, Tag2, Tag3">
+                        </textarea>
+                    </div>
+                    <div class="inputContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="TagMappings">Tag Mappings (one per line: NewTag: original1, original2, ...)</label>
+                        <textarea is="emby-textarea" id="TagMappings" class="textarea-mono emby-textarea" rows="5" style="overflow-y: auto; height: 100px; width: 100%;" placeholder="School: school, schools, classroom, student&#10;Outdoor: outdoor, outside, public">
+                        </textarea>
+                    </div>
+                    <div class="selectContainer">
                         <label class="selectLabel" for="TagStyle">Tag Style</label>
                         <select is="emby-select" id="TagStyle" name="TagStyle" class="emby-select-withcolor emby-select">
                             <option value="Genre">Genre</option>
@@ -190,6 +208,9 @@
                     $('#UseOSHash').prop('checked', config.UseOSHash);
                     $('#OrderStyle').val(config.OrderStyle).change();
                     $('#TagStyle').val(config.TagStyle).change();
+                    $('#TagFilterMode').val(config.TagFilterMode).change();
+                    $('#TagFilterList').val(config.TagFilterList).change();
+                    $('#TagMappings').val(config.TagMappings).change();
                     $('#AddCollectionOnSite').prop('checked', config.AddCollectionOnSite);
                     $('#CollectionMinSize').val(config.CollectionMinSize).change();
                     $('#AddCollectionToCollections').prop('checked', config.AddCollectionToCollections);
@@ -223,6 +244,9 @@
                     config.UseOSHash = $('#UseOSHash').prop('checked');
                     config.OrderStyle = $('#OrderStyle').val();
                     config.TagStyle = $('#TagStyle').val();
+                    config.TagFilterMode = $('#TagFilterMode').val();
+                    config.TagFilterList = $('#TagFilterList').val();
+                    config.TagMappings = $('#TagMappings').val();
                     config.AddCollectionOnSite = $('#AddCollectionOnSite').prop('checked');
                     config.CollectionMinSize = $('#CollectionMinSize').val();
                     config.AddCollectionToCollections = $('#AddCollectionToCollections').prop('checked');


### PR DESCRIPTION
## Summary

This PR adds two new tag management features to give users more control over how tags are processed and displayed:

- **Tag Filtering**: Filter tags using blacklist or whitelist mode
- **Tag Mappings**: Merge multiple similar tags into a single unified tag

## Features

### Tag Filter Mode

A new dropdown with three options:
- **Disabled**: No filtering applied (default)
- **Blacklist**: Remove specific tags from results
- **Whitelist**: Keep only specified tags, remove all others

### Tag Filter List

A comma-separated list of tags to filter based on the selected mode.

Example: `Tag1, Tag2, Tag3`

### Tag Mappings

Define mappings to consolidate multiple related tags into a single tag. Format is one mapping per line:

```
NewTag: original1, original2, original3
```

Example:
```
School: school, schools, classroom, student
Outdoor: outdoor, outside, public
```

When any of the original tags are found, they are replaced with the new unified tag.

## Changes

- Added `TagFilterMode` enum with Disabled, Blacklist, and Whitelist options
- Added `TagFilterList` and `TagMappings` configuration properties
- Added UI controls in the plugin configuration page
- Implemented filtering and mapping logic in the metadata provider

Resolves #105 
